### PR TITLE
Add events resources

### DIFF
--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -48,14 +48,18 @@ from .resources import (
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
+    EventResources,
+    EventLevelResources,
+    EventCategoryResources,
+    TimeseriesByEventResources,
 )
 
 
 APICLI_LOGGER = logging.getLogger(__name__)
 
 REQUIRED_API_VERSION = {
-    "min": Version("0.2.0"),
-    "max": Version("0.3.0"),
+    "min": Version("0.3.0"),
+    "max": Version("0.4.0"),
 }
 
 
@@ -158,6 +162,11 @@ class BEMServerApiClient:
         self.energy_cons_ts_by_buildings = (
             EnergyConsumptionTimseriesByBuildingResources(self._request_manager)
         )
+
+        self.events = EventResources(self._request_manager)
+        self.event_levels = EventLevelResources(self._request_manager)
+        self.event_categories = EventCategoryResources(self._request_manager)
+        self.timeseries_by_events = TimeseriesByEventResources(self._request_manager)
 
     @property
     def uri_prefix(self):

--- a/bemserver_api_client/resources/__init__.py
+++ b/bemserver_api_client/resources/__init__.py
@@ -14,6 +14,11 @@ from .energy import (  # noqa
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
 )
+from .events import (  # noqa
+    EventResources,
+    EventLevelResources,
+    EventCategoryResources,
+)
 from .io import IOResources  # noqa
 from .services import (  # noqa
     ST_CleanupByCampaignResources,
@@ -48,6 +53,7 @@ from .timeseries import (  # noqa
     TimeseriesByStoreyResources,
     TimeseriesBySpaceResources,
     TimeseriesByZoneResources,
+    TimeseriesByEventResources,
 )
 from .users import (  # noqa
     UserResources,

--- a/bemserver_api_client/resources/events.py
+++ b/bemserver_api_client/resources/events.py
@@ -1,0 +1,21 @@
+"""BEMServer API client resources
+
+/event_levels/ endpoints
+/event_categories/ endpoints
+/events/ endpoints
+/timeseries_by_events/ endpoints
+"""
+from .base import BaseResources
+
+
+class EventLevelResources(BaseResources):
+    endpoint_base_uri = "/event_levels/"
+    disabled_endpoints = ["getone", "create", "update", "delete"]
+
+
+class EventCategoryResources(BaseResources):
+    endpoint_base_uri = "/event_categories/"
+
+
+class EventResources(BaseResources):
+    endpoint_base_uri = "/events/"

--- a/bemserver_api_client/resources/timeseries.py
+++ b/bemserver_api_client/resources/timeseries.py
@@ -10,6 +10,7 @@
 /timeseries_by_storeys/ endpoints
 /timeseries_by_spaces/ endpoints
 /timeseries_by_zones/ endpoints
+/timeseries_by_events/ endpoints
 """
 from .base import BaseResources
 from ..enums import DataFormat, Aggregation, BucketWidthUnit
@@ -221,3 +222,7 @@ class TimeseriesBySpaceResources(BaseResources):
 class TimeseriesByZoneResources(BaseResources):
     endpoint_base_uri = "/timeseries_by_zones/"
     disabled_endpoints = ["update"]
+
+
+class TimeseriesByEventResources(BaseResources):
+    endpoint_base_uri = "/timeseries_by_events/"

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -1,0 +1,27 @@
+"""BEMServer API client events resources tests"""
+from bemserver_api_client.resources.base import BaseResources
+from bemserver_api_client.resources import (
+    EventResources,
+    EventLevelResources,
+    EventCategoryResources,
+)
+
+
+class TestAPIClientResourcesEvents:
+    def test_api_client_resources_events(self):
+        assert issubclass(EventResources, BaseResources)
+        assert EventResources.endpoint_base_uri == "/events/"
+        assert EventResources.disabled_endpoints == []
+
+        assert issubclass(EventLevelResources, BaseResources)
+        assert EventLevelResources.endpoint_base_uri == "/event_levels/"
+        assert EventLevelResources.disabled_endpoints == [
+            "getone",
+            "create",
+            "update",
+            "delete",
+        ]
+
+        assert issubclass(EventCategoryResources, BaseResources)
+        assert EventCategoryResources.endpoint_base_uri == "/event_categories/"
+        assert EventCategoryResources.disabled_endpoints == []

--- a/tests/resources/test_resources_timeseries.py
+++ b/tests/resources/test_resources_timeseries.py
@@ -11,6 +11,7 @@ from bemserver_api_client.resources import (
     TimeseriesByStoreyResources,
     TimeseriesBySpaceResources,
     TimeseriesByZoneResources,
+    TimeseriesByEventResources,
 )
 from bemserver_api_client.response import BEMServerApiClientResponse
 from bemserver_api_client.enums import DataFormat, Aggregation
@@ -82,6 +83,10 @@ class TestAPIClientResourcesTimeseries:
         assert issubclass(TimeseriesByZoneResources, BaseResources)
         assert TimeseriesByZoneResources.endpoint_base_uri == "/timeseries_by_zones/"
         assert TimeseriesByZoneResources.disabled_endpoints == ["update"]
+
+        assert issubclass(TimeseriesByEventResources, BaseResources)
+        assert TimeseriesByEventResources.endpoint_base_uri == "/timeseries_by_events/"
+        assert TimeseriesByEventResources.disabled_endpoints == []
 
     def test_api_client_resources_timeseries_endpoints(self, mock_request):
         ts_res = TimeseriesResources(mock_request)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,6 +45,10 @@ from bemserver_api_client.resources import (
     AnalysisResources,
     ST_CleanupByCampaignResources,
     ST_CleanupByTimeseriesResources,
+    EventResources,
+    EventLevelResources,
+    EventCategoryResources,
+    TimeseriesByEventResources,
 )
 
 
@@ -171,6 +175,16 @@ class TestAPIClient:
         assert isinstance(
             apicli.st_cleanup_by_timeseries, ST_CleanupByTimeseriesResources
         )
+
+        assert hasattr(apicli, "events")
+        assert isinstance(apicli.events, EventResources)
+        assert hasattr(apicli, "event_levels")
+        assert isinstance(apicli.event_levels, EventLevelResources)
+        assert hasattr(apicli, "event_categories")
+        assert isinstance(apicli.event_categories, EventCategoryResources)
+
+        assert hasattr(apicli, "timeseries_by_events")
+        assert isinstance(apicli.timeseries_by_events, TimeseriesByEventResources)
 
         assert not hasattr(apicli, "whatever_resources_that_does_not_exist")
 


### PR DESCRIPTION
- Bump required API version (>=0.3.0,<0.4.0)
- Add /events/, /event_levels/, /event_categories/ and /timeseries_by_events/ endpoints