### PR TITLE
Update events

### DIFF
--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -52,6 +52,11 @@ from .resources import (
     EventResources,
     EventLevelResources,
     EventCategoryResources,
+    EventBySiteResources,
+    EventByBuildingResources,
+    EventByStoreyResources,
+    EventBySpaceResources,
+    EventByZoneResources,
     TimeseriesByEventResources,
 )
 
@@ -59,8 +64,8 @@ from .resources import (
 APICLI_LOGGER = logging.getLogger(__name__)
 
 REQUIRED_API_VERSION = {
-    "min": Version("0.3.0"),
-    "max": Version("0.4.0"),
+    "min": Version("0.4.0"),
+    "max": Version("0.5.0"),
 }
 
 
@@ -171,6 +176,11 @@ class BEMServerApiClient:
         self.events = EventResources(self._request_manager)
         self.event_levels = EventLevelResources(self._request_manager)
         self.event_categories = EventCategoryResources(self._request_manager)
+        self.event_by_sites = EventBySiteResources(self._request_manager)
+        self.event_by_buildings = EventByBuildingResources(self._request_manager)
+        self.event_by_storeys = EventByStoreyResources(self._request_manager)
+        self.event_by_spaces = EventBySpaceResources(self._request_manager)
+        self.event_by_zones = EventByZoneResources(self._request_manager)
         self.timeseries_by_events = TimeseriesByEventResources(self._request_manager)
 
     @property

--- a/bemserver_api_client/resources/__init__.py
+++ b/bemserver_api_client/resources/__init__.py
@@ -18,6 +18,11 @@ from .events import (  # noqa
     EventResources,
     EventLevelResources,
     EventCategoryResources,
+    EventBySiteResources,
+    EventByBuildingResources,
+    EventByStoreyResources,
+    EventBySpaceResources,
+    EventByZoneResources,
 )
 from .io import IOResources  # noqa
 from .services import (  # noqa

--- a/bemserver_api_client/resources/events.py
+++ b/bemserver_api_client/resources/events.py
@@ -3,7 +3,11 @@
 /event_levels/ endpoints
 /event_categories/ endpoints
 /events/ endpoints
-/timeseries_by_events/ endpoints
+/events_by_sites/ endpoints
+/events_by_buildings/ endpoints
+/events_by_storeys/ endpoints
+/events_by_spaces/ endpoints
+/events_by_zones/ endpoints
 """
 from .base import BaseResources
 
@@ -19,3 +23,28 @@ class EventCategoryResources(BaseResources):
 
 class EventResources(BaseResources):
     endpoint_base_uri = "/events/"
+
+
+class EventBySiteResources(BaseResources):
+    endpoint_base_uri = "/events_by_sites/"
+    disabled_endpoints = ["update"]
+
+
+class EventByBuildingResources(BaseResources):
+    endpoint_base_uri = "/events_by_buildings/"
+    disabled_endpoints = ["update"]
+
+
+class EventByStoreyResources(BaseResources):
+    endpoint_base_uri = "/events_by_storeys/"
+    disabled_endpoints = ["update"]
+
+
+class EventBySpaceResources(BaseResources):
+    endpoint_base_uri = "/events_by_spaces/"
+    disabled_endpoints = ["update"]
+
+
+class EventByZoneResources(BaseResources):
+    endpoint_base_uri = "/events_by_zones/"
+    disabled_endpoints = ["update"]

--- a/bemserver_api_client/resources/timeseries.py
+++ b/bemserver_api_client/resources/timeseries.py
@@ -226,3 +226,4 @@ class TimeseriesByZoneResources(BaseResources):
 
 class TimeseriesByEventResources(BaseResources):
     endpoint_base_uri = "/timeseries_by_events/"
+    disabled_endpoints = ["update"]

--- a/tests/resources/test_events.py
+++ b/tests/resources/test_events.py
@@ -4,6 +4,11 @@ from bemserver_api_client.resources import (
     EventResources,
     EventLevelResources,
     EventCategoryResources,
+    EventBySiteResources,
+    EventByBuildingResources,
+    EventByStoreyResources,
+    EventBySpaceResources,
+    EventByZoneResources,
 )
 
 
@@ -25,3 +30,23 @@ class TestAPIClientResourcesEvents:
         assert issubclass(EventCategoryResources, BaseResources)
         assert EventCategoryResources.endpoint_base_uri == "/event_categories/"
         assert EventCategoryResources.disabled_endpoints == []
+
+        assert issubclass(EventBySiteResources, BaseResources)
+        assert EventBySiteResources.endpoint_base_uri == "/events_by_sites/"
+        assert EventBySiteResources.disabled_endpoints == ["update"]
+
+        assert issubclass(EventByBuildingResources, BaseResources)
+        assert EventByBuildingResources.endpoint_base_uri == "/events_by_buildings/"
+        assert EventByBuildingResources.disabled_endpoints == ["update"]
+
+        assert issubclass(EventByStoreyResources, BaseResources)
+        assert EventByStoreyResources.endpoint_base_uri == "/events_by_storeys/"
+        assert EventByStoreyResources.disabled_endpoints == ["update"]
+
+        assert issubclass(EventBySpaceResources, BaseResources)
+        assert EventBySpaceResources.endpoint_base_uri == "/events_by_spaces/"
+        assert EventBySpaceResources.disabled_endpoints == ["update"]
+
+        assert issubclass(EventByZoneResources, BaseResources)
+        assert EventByZoneResources.endpoint_base_uri == "/events_by_zones/"
+        assert EventByZoneResources.disabled_endpoints == ["update"]

--- a/tests/resources/test_resources_timeseries.py
+++ b/tests/resources/test_resources_timeseries.py
@@ -86,7 +86,7 @@ class TestAPIClientResourcesTimeseries:
 
         assert issubclass(TimeseriesByEventResources, BaseResources)
         assert TimeseriesByEventResources.endpoint_base_uri == "/timeseries_by_events/"
-        assert TimeseriesByEventResources.disabled_endpoints == []
+        assert TimeseriesByEventResources.disabled_endpoints == ["update"]
 
     def test_api_client_resources_timeseries_endpoints(self, mock_request):
         ts_res = TimeseriesResources(mock_request)


### PR DESCRIPTION
- Upgrade bemserver-api required version (>=0.4.0, <0.5.0)
- Add events by sites/buildings/storeys/spaces/zones resources
- Remove update on timeseries by events resource