### PR TITLE
Improve response client error processing

### DIFF
--- a/bemserver_api_client/exceptions.py
+++ b/bemserver_api_client/exceptions.py
@@ -12,6 +12,14 @@ class BEMServerAPIError(Exception):
         self.status_code = status_code
 
 
+class BEMServerAPIConflictError(BEMServerAPIError):
+    """BEMServer API conflict error"""
+
+    def __init__(self, message=None):
+        super().__init__(status_code=409)
+        self.message = message
+
+
 class BEMServerAPIValidationError(BEMServerAPIError):
     """BEMServer API validation error"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,8 @@ def mock_raw_response_internal_error(request):
     )
 
 
-@pytest.fixture(params=[{"is_general": False, "is_json": True}])
+@pytest.fixture(params=[{"is_json": True}])
 def mock_raw_response_409(request):
-    is_general = request.param.get("is_general", False)
     is_json = request.param.get("is_json", True)
 
     resp = requests.Response()
@@ -68,17 +67,12 @@ def mock_raw_response_409(request):
             "code": 409,
             "errors": {},
             "status": "Conflict",
+            "message": "Unique constraint violation",
         }
-        if not is_general:
-            resp_content["errors"] = {
-                "type": "unique_constraint",
-                "fields": ["name"],
-            }
         resp._content = json.dumps(resp_content).encode("utf-8")
 
     return (
         resp,
-        is_general,
         is_json,
     )
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -3,6 +3,7 @@ import pytest
 
 from bemserver_api_client.response import BEMServerApiClientResponse
 from bemserver_api_client.response import (
+    BEMServerAPIConflictError,
     BEMServerAPIValidationError,
     BEMServerAPIInternalError,
 )
@@ -42,27 +43,19 @@ class TestAPIClientResponse:
     @pytest.mark.parametrize(
         "mock_raw_response_409",
         (
-            {"is_general": False},
-            {"is_general": True},
+            {"is_json": True},
             {"is_json": False},
         ),
         indirect=True,
     )
     def test_api_client_response_error_409(self, mock_raw_response_409):
-        raw_resp, is_general, is_json = mock_raw_response_409
-        with pytest.raises(BEMServerAPIValidationError) as excinfo:
+        raw_resp, is_json = mock_raw_response_409
+        with pytest.raises(BEMServerAPIConflictError) as excinfo:
             BEMServerApiClientResponse(raw_resp)
         if is_json:
-            if is_general:
-                assert excinfo.value.errors == {
-                    "_general": ["Operation failed (409)."],
-                }
-            else:
-                assert excinfo.value.errors == {
-                    "name": ["Must be unique."],
-                }
+            assert excinfo.value.message == "Unique constraint violation"
         else:
-            assert excinfo.value.errors == {}
+            assert excinfo.value.message == "Operation failed (409)!"
 
     @pytest.mark.parametrize(
         "mock_raw_response_422",


### PR DESCRIPTION
Split 409 and 422 status codes processing.
Add BEMServerAPIConflictError exception for 409 status code, with message attribute.