### PR TITLE
Upgrade required API version (>=0.13.0,<0.14.0)

### DIFF
--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -46,7 +46,7 @@ from .resources import (
     ST_CleanupByTimeseriesResources,
     ST_CheckMissingByCampaignResources,
     ST_CheckOutlierByCampaignResources,
-    EnergySourceResources,
+    EnergyResources,
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
@@ -170,7 +170,7 @@ class BEMServerApiClient:
             self._request_manager
         )
 
-        self.energy_sources = EnergySourceResources(self._request_manager)
+        self.energies = EnergyResources(self._request_manager)
         self.energy_end_uses = EnergyEndUseResources(self._request_manager)
         self.energy_cons_ts_by_sites = EnergyConsumptionTimseriesBySiteResources(
             self._request_manager

--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -66,8 +66,8 @@ from .resources import (
 APICLI_LOGGER = logging.getLogger(__name__)
 
 REQUIRED_API_VERSION = {
-    "min": Version("0.12.1"),
-    "max": Version("0.13.0"),
+    "min": Version("0.13.0"),
+    "max": Version("0.14.0"),
 }
 
 

--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -50,6 +50,7 @@ from .resources import (
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
+    EnergyProductionTechnologyResources,
     EventResources,
     EventCategoryResources,
     EventCategoryByUserResources,
@@ -177,6 +178,9 @@ class BEMServerApiClient:
         )
         self.energy_cons_ts_by_buildings = (
             EnergyConsumptionTimseriesByBuildingResources(self._request_manager)
+        )
+        self.energy_prod_technologies = EnergyProductionTechnologyResources(
+            self._request_manager
         )
 
         self.events = EventResources(self._request_manager)

--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -51,6 +51,8 @@ from .resources import (
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
     EnergyProductionTechnologyResources,
+    EnergyProductionTimseriesBySiteResources,
+    EnergyProductionTimseriesByBuildingResources,
     EventResources,
     EventCategoryResources,
     EventCategoryByUserResources,
@@ -180,6 +182,12 @@ class BEMServerApiClient:
             EnergyConsumptionTimseriesByBuildingResources(self._request_manager)
         )
         self.energy_prod_technologies = EnergyProductionTechnologyResources(
+            self._request_manager
+        )
+        self.energy_prod_ts_by_sites = EnergyProductionTimseriesBySiteResources(
+            self._request_manager
+        )
+        self.energy_prod_ts_by_buildings = EnergyProductionTimseriesByBuildingResources(
             self._request_manager
         )
 

--- a/bemserver_api_client/client.py
+++ b/bemserver_api_client/client.py
@@ -53,6 +53,7 @@ from .resources import (
     EnergyProductionTechnologyResources,
     EnergyProductionTimseriesBySiteResources,
     EnergyProductionTimseriesByBuildingResources,
+    WeatherTimseriesBySiteResources,
     EventResources,
     EventCategoryResources,
     EventCategoryByUserResources,
@@ -188,6 +189,9 @@ class BEMServerApiClient:
             self._request_manager
         )
         self.energy_prod_ts_by_buildings = EnergyProductionTimseriesByBuildingResources(
+            self._request_manager
+        )
+        self.weather_ts_by_sites = WeatherTimseriesBySiteResources(
             self._request_manager
         )
 

--- a/bemserver_api_client/resources/__init__.py
+++ b/bemserver_api_client/resources/__init__.py
@@ -13,6 +13,7 @@ from .energy import (  # noqa
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
+    EnergyProductionTechnologyResources,
 )
 from .events import (  # noqa
     EventResources,

--- a/bemserver_api_client/resources/__init__.py
+++ b/bemserver_api_client/resources/__init__.py
@@ -71,3 +71,4 @@ from .users import (  # noqa
     UserGroupResources,
     UserByUserGroupResources,
 )
+from .weather import WeatherTimseriesBySiteResources  # noqa

--- a/bemserver_api_client/resources/__init__.py
+++ b/bemserver_api_client/resources/__init__.py
@@ -9,7 +9,7 @@ from .campaigns import (  # noqa
     UserGroupByCampaignScopeResources,
 )
 from .energy import (  # noqa
-    EnergySourceResources,
+    EnergyResources,
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,

--- a/bemserver_api_client/resources/__init__.py
+++ b/bemserver_api_client/resources/__init__.py
@@ -14,6 +14,8 @@ from .energy import (  # noqa
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
     EnergyProductionTechnologyResources,
+    EnergyProductionTimseriesBySiteResources,
+    EnergyProductionTimseriesByBuildingResources,
 )
 from .events import (  # noqa
     EventResources,

--- a/bemserver_api_client/resources/energy.py
+++ b/bemserver_api_client/resources/energy.py
@@ -1,6 +1,6 @@
 """BEMServer API client resources
 
-/energy_sources/ endpoints
+/energies/ endpoints
 /energy_end_uses/ endpoints
 /energy_consumption_timeseries_by_sites/ endpoints
 /energy_consumption_timeseries_by_buildings/ endpoints
@@ -8,8 +8,8 @@
 from .base import BaseResources
 
 
-class EnergySourceResources(BaseResources):
-    endpoint_base_uri = "/energy_sources/"
+class EnergyResources(BaseResources):
+    endpoint_base_uri = "/energies/"
     disabled_endpoints = ["getone", "create", "update", "delete"]
 
 

--- a/bemserver_api_client/resources/energy.py
+++ b/bemserver_api_client/resources/energy.py
@@ -5,6 +5,8 @@
 /energy_consumption_timeseries_by_sites/ endpoints
 /energy_consumption_timeseries_by_buildings/ endpoints
 /energy_production_technologies/ endpoints
+/energy_production_timeseries_by_sites/ endpoints
+/energy_production_timeseries_by_buildings/ endpoints
 """
 from .base import BaseResources
 
@@ -30,3 +32,11 @@ class EnergyConsumptionTimseriesByBuildingResources(BaseResources):
 class EnergyProductionTechnologyResources(BaseResources):
     endpoint_base_uri = "/energy_production_technologies/"
     disabled_endpoints = ["getone", "create", "update", "delete"]
+
+
+class EnergyProductionTimseriesBySiteResources(BaseResources):
+    endpoint_base_uri = "/energy_production_timeseries_by_sites/"
+
+
+class EnergyProductionTimseriesByBuildingResources(BaseResources):
+    endpoint_base_uri = "/energy_production_timeseries_by_buildings/"

--- a/bemserver_api_client/resources/energy.py
+++ b/bemserver_api_client/resources/energy.py
@@ -4,6 +4,7 @@
 /energy_end_uses/ endpoints
 /energy_consumption_timeseries_by_sites/ endpoints
 /energy_consumption_timeseries_by_buildings/ endpoints
+/energy_production_technologies/ endpoints
 """
 from .base import BaseResources
 
@@ -24,3 +25,8 @@ class EnergyConsumptionTimseriesBySiteResources(BaseResources):
 
 class EnergyConsumptionTimseriesByBuildingResources(BaseResources):
     endpoint_base_uri = "/energy_consumption_timeseries_by_buildings/"
+
+
+class EnergyProductionTechnologyResources(BaseResources):
+    endpoint_base_uri = "/energy_production_technologies/"
+    disabled_endpoints = ["getone", "create", "update", "delete"]

--- a/bemserver_api_client/resources/weather.py
+++ b/bemserver_api_client/resources/weather.py
@@ -1,0 +1,9 @@
+"""BEMServer API client resources
+
+/weather_timeseries_by_sites/ endpoints
+"""
+from .base import BaseResources
+
+
+class WeatherTimseriesBySiteResources(BaseResources):
+    endpoint_base_uri = "/weather_timeseries_by_sites/"

--- a/tests/resources/test_resources_energy.py
+++ b/tests/resources/test_resources_energy.py
@@ -1,18 +1,18 @@
 """BEMServer API client energy resources tests"""
 from bemserver_api_client.resources.base import BaseResources
 from bemserver_api_client.resources import (
-    EnergySourceResources,
+    EnergyResources,
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
 )
 
 
-class TestAPIClientResourcesEnergySources:
-    def test_api_client_resources_energy_sources(self):
-        assert issubclass(EnergySourceResources, BaseResources)
-        assert EnergySourceResources.endpoint_base_uri == "/energy_sources/"
-        assert EnergySourceResources.disabled_endpoints == [
+class TestAPIClientResourcesEnergies:
+    def test_api_client_resources_energies(self):
+        assert issubclass(EnergyResources, BaseResources)
+        assert EnergyResources.endpoint_base_uri == "/energies/"
+        assert EnergyResources.disabled_endpoints == [
             "getone",
             "create",
             "update",

--- a/tests/resources/test_resources_energy.py
+++ b/tests/resources/test_resources_energy.py
@@ -6,6 +6,8 @@ from bemserver_api_client.resources import (
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
     EnergyProductionTechnologyResources,
+    EnergyProductionTimseriesBySiteResources,
+    EnergyProductionTimseriesByBuildingResources,
 )
 
 
@@ -60,3 +62,18 @@ class TestAPIClientResourcesEnergyProductionTechnologies:
             "update",
             "delete",
         ]
+
+
+class TestAPIClientResourcesEnergyProduction:
+    def test_api_client_resources_energy_production(self):
+        assert issubclass(EnergyProductionTimseriesBySiteResources, BaseResources)
+        assert EnergyProductionTimseriesBySiteResources.endpoint_base_uri == (
+            "/energy_production_timeseries_by_sites/"
+        )
+        assert EnergyProductionTimseriesBySiteResources.disabled_endpoints == []
+
+        assert issubclass(EnergyProductionTimseriesByBuildingResources, BaseResources)
+        assert EnergyProductionTimseriesByBuildingResources.endpoint_base_uri == (
+            "/energy_production_timeseries_by_buildings/"
+        )
+        assert EnergyProductionTimseriesByBuildingResources.disabled_endpoints == []

--- a/tests/resources/test_resources_energy.py
+++ b/tests/resources/test_resources_energy.py
@@ -5,6 +5,7 @@ from bemserver_api_client.resources import (
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
+    EnergyProductionTechnologyResources,
 )
 
 
@@ -45,3 +46,17 @@ class TestAPIClientResourcesEnergyConsumption:
             "/energy_consumption_timeseries_by_buildings/"
         )
         assert EnergyConsumptionTimseriesByBuildingResources.disabled_endpoints == []
+
+
+class TestAPIClientResourcesEnergyProductionTechnologies:
+    def test_api_client_resources_energy_prod_technos(self):
+        assert issubclass(EnergyProductionTechnologyResources, BaseResources)
+        assert EnergyProductionTechnologyResources.endpoint_base_uri == (
+            "/energy_production_technologies/"
+        )
+        assert EnergyProductionTechnologyResources.disabled_endpoints == [
+            "getone",
+            "create",
+            "update",
+            "delete",
+        ]

--- a/tests/resources/test_resources_weather.py
+++ b/tests/resources/test_resources_weather.py
@@ -1,0 +1,12 @@
+"""BEMServer API client weather resources tests"""
+from bemserver_api_client.resources.base import BaseResources
+from bemserver_api_client.resources import WeatherTimseriesBySiteResources
+
+
+class TestAPIClientResourcesWeather:
+    def test_api_client_resources_weather(self):
+        assert issubclass(WeatherTimseriesBySiteResources, BaseResources)
+        assert WeatherTimseriesBySiteResources.endpoint_base_uri == (
+            "/weather_timeseries_by_sites/"
+        )
+        assert WeatherTimseriesBySiteResources.disabled_endpoints == []

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,6 +52,8 @@ from bemserver_api_client.resources import (
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
     EnergyProductionTechnologyResources,
+    EnergyProductionTimseriesBySiteResources,
+    EnergyProductionTimseriesByBuildingResources,
     EventResources,
     EventCategoryResources,
     EventCategoryByUserResources,
@@ -215,6 +217,15 @@ class TestAPIClient:
         assert hasattr(apicli, "energy_prod_technologies")
         assert isinstance(
             apicli.energy_prod_technologies, EnergyProductionTechnologyResources
+        )
+        assert hasattr(apicli, "energy_prod_ts_by_sites")
+        assert isinstance(
+            apicli.energy_prod_ts_by_sites, EnergyProductionTimseriesBySiteResources
+        )
+        assert hasattr(apicli, "energy_prod_ts_by_buildings")
+        assert isinstance(
+            apicli.energy_prod_ts_by_buildings,
+            EnergyProductionTimseriesByBuildingResources,
         )
 
         assert hasattr(apicli, "events")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -54,6 +54,7 @@ from bemserver_api_client.resources import (
     EnergyProductionTechnologyResources,
     EnergyProductionTimseriesBySiteResources,
     EnergyProductionTimseriesByBuildingResources,
+    WeatherTimseriesBySiteResources,
     EventResources,
     EventCategoryResources,
     EventCategoryByUserResources,
@@ -227,6 +228,8 @@ class TestAPIClient:
             apicli.energy_prod_ts_by_buildings,
             EnergyProductionTimseriesByBuildingResources,
         )
+        assert hasattr(apicli, "weather_ts_by_sites")
+        assert isinstance(apicli.weather_ts_by_sites, WeatherTimseriesBySiteResources)
 
         assert hasattr(apicli, "events")
         assert isinstance(apicli.events, EventResources)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,10 +46,21 @@ from bemserver_api_client.resources import (
     ST_CleanupByCampaignResources,
     ST_CleanupByTimeseriesResources,
     ST_CheckMissingByCampaignResources,
+    ST_CheckOutlierByCampaignResources,
     EnergyResources,
+    EnergyEndUseResources,
+    EnergyConsumptionTimseriesBySiteResources,
+    EnergyConsumptionTimseriesByBuildingResources,
     EventResources,
     EventCategoryResources,
+    EventCategoryByUserResources,
+    EventBySiteResources,
+    EventByBuildingResources,
+    EventByStoreyResources,
+    EventBySpaceResources,
+    EventByZoneResources,
     TimeseriesByEventResources,
+    NotificationResources,
 )
 
 
@@ -182,16 +193,49 @@ class TestAPIClient:
             apicli.st_check_missing_by_campaign, ST_CheckMissingByCampaignResources
         )
 
+        assert hasattr(apicli, "st_check_outlier_by_campaign")
+        assert isinstance(
+            apicli.st_check_outlier_by_campaign, ST_CheckOutlierByCampaignResources
+        )
+
         assert hasattr(apicli, "energies")
         assert isinstance(apicli.energies, EnergyResources)
+        assert hasattr(apicli, "energy_end_uses")
+        assert isinstance(apicli.energy_end_uses, EnergyEndUseResources)
+        assert hasattr(apicli, "energy_cons_ts_by_sites")
+        assert isinstance(
+            apicli.energy_cons_ts_by_sites, EnergyConsumptionTimseriesBySiteResources
+        )
+        assert hasattr(apicli, "energy_cons_ts_by_buildings")
+        assert isinstance(
+            apicli.energy_cons_ts_by_buildings,
+            EnergyConsumptionTimseriesByBuildingResources,
+        )
 
         assert hasattr(apicli, "events")
         assert isinstance(apicli.events, EventResources)
         assert hasattr(apicli, "event_categories")
         assert isinstance(apicli.event_categories, EventCategoryResources)
+        assert hasattr(apicli, "event_categories_by_users")
+        assert isinstance(
+            apicli.event_categories_by_users, EventCategoryByUserResources
+        )
 
+        assert hasattr(apicli, "event_by_sites")
+        assert isinstance(apicli.event_by_sites, EventBySiteResources)
+        assert hasattr(apicli, "event_by_buildings")
+        assert isinstance(apicli.event_by_buildings, EventByBuildingResources)
+        assert hasattr(apicli, "event_by_storeys")
+        assert isinstance(apicli.event_by_storeys, EventByStoreyResources)
+        assert hasattr(apicli, "event_by_spaces")
+        assert isinstance(apicli.event_by_spaces, EventBySpaceResources)
+        assert hasattr(apicli, "event_by_zones")
+        assert isinstance(apicli.event_by_zones, EventByZoneResources)
         assert hasattr(apicli, "timeseries_by_events")
         assert isinstance(apicli.timeseries_by_events, TimeseriesByEventResources)
+
+        assert hasattr(apicli, "notifications")
+        assert isinstance(apicli.notifications, NotificationResources)
 
         assert not hasattr(apicli, "whatever_resources_that_does_not_exist")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,6 +51,7 @@ from bemserver_api_client.resources import (
     EnergyEndUseResources,
     EnergyConsumptionTimseriesBySiteResources,
     EnergyConsumptionTimseriesByBuildingResources,
+    EnergyProductionTechnologyResources,
     EventResources,
     EventCategoryResources,
     EventCategoryByUserResources,
@@ -210,6 +211,10 @@ class TestAPIClient:
         assert isinstance(
             apicli.energy_cons_ts_by_buildings,
             EnergyConsumptionTimseriesByBuildingResources,
+        )
+        assert hasattr(apicli, "energy_prod_technologies")
+        assert isinstance(
+            apicli.energy_prod_technologies, EnergyProductionTechnologyResources
         )
 
         assert hasattr(apicli, "events")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,6 +46,7 @@ from bemserver_api_client.resources import (
     ST_CleanupByCampaignResources,
     ST_CleanupByTimeseriesResources,
     ST_CheckMissingByCampaignResources,
+    EnergyResources,
     EventResources,
     EventCategoryResources,
     TimeseriesByEventResources,
@@ -180,6 +181,9 @@ class TestAPIClient:
         assert isinstance(
             apicli.st_check_missing_by_campaign, ST_CheckMissingByCampaignResources
         )
+
+        assert hasattr(apicli, "energies")
+        assert isinstance(apicli.energies, EnergyResources)
 
         assert hasattr(apicli, "events")
         assert isinstance(apicli.events, EventResources)


### PR DESCRIPTION
- Upgrade required API version
- Rename EnergySourceResources to EnergyResources (/energy_sources/ to /energies/)
- Add EnergyProduction* resources (technologies, timeseries by sites/buildings)
- Add WeatherTimeseriesBySite resources (/weather_timeseries_by_sites/)