### PR TITLE
Add SiteResources.download_weather_data endpoint

### DIFF
--- a/bemserver_api_client/resources/structural_elements.py
+++ b/bemserver_api_client/resources/structural_elements.py
@@ -24,6 +24,16 @@ class SiteResources(BaseResources):
     endpoint_base_uri = "/sites/"
     client_entrypoint = "sites"
 
+    def download_weather_data(self, id, start_time, end_time):
+        return self._req._execute(
+            "PUT",
+            f"{self.enpoint_uri_by_id(id)}/download_weather_data",
+            params={
+                "start_time": start_time,
+                "end_time": end_time,
+            },
+        )
+
 
 class BuildingResources(BaseResources):
     endpoint_base_uri = "/buildings/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from bemserver_api_client.resources.services import (
     ST_CheckOutlierByCampaignResources,
     ST_DownloadWeatherDataBySiteResources,
 )
+from bemserver_api_client.resources.structural_elements import SiteResources
 from bemserver_api_client.enums import (
     DataFormat,
     Aggregation,
@@ -145,6 +146,7 @@ def mock_session(uri_prefix, base_uri):
     mock_check_missing_uris(adapter, base_uri)
     mock_check_outlier_uris(adapter, base_uri)
     mock_download_weather_uris(adapter, base_uri)
+    mock_site_download_weather_data_uris(adapter, base_uri)
 
     session = requests.Session()
     session.mount(f"{uri_prefix}://", adapter)
@@ -1215,4 +1217,23 @@ def mock_download_weather_uris(mock_adapter, base_uri):
                 "site_name": "Talence",
             },
         ],
+    )
+
+
+def mock_site_download_weather_data_uris(mock_adapter, base_uri):
+    q_params = {
+        "start_time": "2020-01-01T00:00:00+00:00",
+        "end_time": "2020-01-01T00:30:00+00:00",
+    }
+    mock_adapter.register_uri(
+        "PUT",
+        (
+            f"{base_uri}{SiteResources.endpoint_base_uri}1/download_weather_data"
+            f"?{urllib.parse.urlencode(q_params, True)}"
+        ),
+        headers={
+            "Content-Type": "application/json",
+        },
+        json={},
+        status_code=204,
     )

--- a/tests/resources/test_resources_structural_elements.py
+++ b/tests/resources/test_resources_structural_elements.py
@@ -18,6 +18,7 @@ from bemserver_api_client.resources.structural_elements import (
     ZonePropertyResources,
     ZonePropertyDataResources,
 )
+from bemserver_api_client.response import BEMServerApiClientResponse
 
 
 class TestAPIClientResourcesStructuralElements:
@@ -26,6 +27,7 @@ class TestAPIClientResourcesStructuralElements:
         assert SiteResources.endpoint_base_uri == "/sites/"
         assert SiteResources.disabled_endpoints == []
         assert SiteResources.client_entrypoint == "sites"
+        assert hasattr(SiteResources, "download_weather_data")
 
         assert issubclass(BuildingResources, BaseResources)
         assert BuildingResources.endpoint_base_uri == "/buildings/"
@@ -111,3 +113,19 @@ class TestAPIClientResourcesStructuralElements:
         assert ZonePropertyDataResources.endpoint_base_uri == "/zone_property_data/"
         assert ZonePropertyDataResources.disabled_endpoints == []
         assert ZonePropertyDataResources.client_entrypoint == "zone_property_data"
+
+    def test_api_client_resources_sites_endpoints(self, mock_request):
+        site_res = SiteResources(mock_request)
+
+        resp = site_res.download_weather_data(
+            1,
+            "2020-01-01T00:00:00+00:00",
+            "2020-01-01T00:30:00+00:00",
+        )
+        assert isinstance(resp, BEMServerApiClientResponse)
+        assert resp.status_code == 204
+        assert resp.is_json
+        assert not resp.is_csv
+        assert resp.pagination == {}
+        assert resp.etag == ""
+        assert resp.data == {}


### PR DESCRIPTION
This resources exists in API since version 0.17.0 and was forgotten in the previous update.